### PR TITLE
feature/TC-route-to-use-the-classifier: Route, controller and validation for classifier

### DIFF
--- a/app/Http/Controllers/TextController.php
+++ b/app/Http/Controllers/TextController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ClassifyTextRequest;
+use App\Services\Classifiers\Libs\Phpml;
+use App\Services\Classifiers\TextEmotionService;
+use App\Services\Classifiers\TextHateDeterctorService;
+use Illuminate\Http\Request;
+
+class TextController extends Controller
+{
+    public function classify(ClassifyTextRequest $request)
+    {
+        $phrase = $request->input('phrase');
+
+        $phpml = app(Phpml::class);
+
+        $emotion = (new TextEmotionService($phpml))->predict([$phrase]);
+        $hateDetector = (new TextHateDeterctorService($phpml))->predict([$phrase]);
+
+        return response()->json([
+            'emotion' => $emotion,
+            'is_hate' => $hateDetector,
+        ]);
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,6 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        'api/texts/classify', // @internal It cannot be disabled on real situation, I'm disabling because it's a simple PoC
     ];
 }

--- a/app/Http/Requests/ClassifyTextRequest.php
+++ b/app/Http/Requests/ClassifyTextRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ClassifyTextRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'phrase' => 'required|string|max:255',
+        ];
+    }
+}

--- a/app/Services/Classifiers/AbstractClassifier.php
+++ b/app/Services/Classifiers/AbstractClassifier.php
@@ -20,7 +20,7 @@ abstract class AbstractClassifier
         return $this->ml->predict($text);
     }
 
-    private function train(array $samples, array $labels)
+    private function train(array $samples, array $labels): void
     {
         $this->ml->train($samples, $labels);
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\TextController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -13,6 +14,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
+Route::prefix('api')->group(function () {
+    Route::post('/texts/classify', [TextController::class, 'classify']);
 });


### PR DESCRIPTION
# Feature: Route, Controller, and Validation for Text Classification

This PR adds the infrastructure to classify text using our ML services.

## Changes

1. **Route**
   - Added API route: `POST /api/texts/classify` to receive phrases for classification.

2. **Controller**
   - `TextController` with `classify` method.
   - Uses `TextEmotionService` and `TextHateDeterctorService` to predict the emotion and hate content of the input text.

3. **Request Validation**
   - `ClassifyTextRequest` validates incoming requests:
     - `phrase` is required, string, max 255 characters.

4. **CSRF Exclusion**
   - `/api/texts/classify` route is excluded from CSRF verification for API usage.

## Example Response

```json
{
    "emotion": "joy",
    "is_hate": "negative"
}
